### PR TITLE
Implement YouTube link and icons in dropdown view

### DIFF
--- a/app/views/index-dropdown.ejs
+++ b/app/views/index-dropdown.ejs
@@ -139,8 +139,18 @@
       }
 
       elOwner.textContent = selectedOwner;
-      elUtube.textContent = '<a onclick="" title="Video">v</a>';
-      elDesc.textContent = '<a onclick="" title="Info">i</a>';
+
+      if (selectedUtube && selectedUtube !== "0") {
+        elUtube.innerHTML = `<a onclick="window.parent.document.getElementById('youtubeEmbed').click()" title="Video" style="margin-left: 10px; cursor: pointer;"><i class="glyphicon glyphicon-play-circle" style="font-size: 25px;"></i></a>`;
+      } else {
+        elUtube.innerHTML = "";
+      }
+
+      if (selectedDesc && selectedDesc !== "0") {
+        elDesc.innerHTML = `<a title="Info" style="margin-left: 10px; cursor: pointer;"><i class="glyphicon glyphicon-info-sign" style="font-size: 25px;"></i></a>`;
+      } else {
+        elDesc.innerHTML = "";
+      }
     }
   </script>
 </html>


### PR DESCRIPTION
The changes implement the requested feature where selecting a chart with associated YouTube data displays a clickable icon that interacts with the parent frame. It also fixes a bug where HTML tags were displayed as literal text due to the use of textContent. Verification was performed using a Playwright script that mocked the parent frame interaction and confirmed correct visual and behavioral outcomes.

---
*PR created automatically by Jules for task [4787127167309641252](https://jules.google.com/task/4787127167309641252) started by @irvanfauzie*